### PR TITLE
feat: improve error handling and add unit tests

### DIFF
--- a/include/tooi/core/token.h
+++ b/include/tooi/core/token.h
@@ -17,6 +17,7 @@ enum class TokenType {
     COMMA, DOT, MINUS, PLUS, SEMICOLON, SLASH, ASTERISK,
     AT, QUOTE, HASHTAG, DOLLAR, QUESTION, COLON,
     CARET, PERCENT, AMPERSAND, PIPE, TILDE,
+    // Quote is not currently supported as a token type. Reserved.
 
     // One or two character tokens.
     BANG, BANG_EQUAL,

--- a/src/core/error_registry.cpp
+++ b/src/core/error_registry.cpp
@@ -24,18 +24,13 @@ ErrorRegistry& ErrorRegistry::instance() {
 
 // Get ErrorInfo by code
 const ErrorInfo& ErrorRegistry::get_info(ErrorCode code) const {
-    try {
-        return registry_map_.at(code);
-    } catch (const std::out_of_range& oor) {
-        // Provide a fallback error message if the requested code is unknown
-        try {
-             return registry_map_.at(ErrorCode::Registry_UnknownErrorCode);
-        } catch (...) {
-            // If even the fallback is missing (shouldn't happen), throw a basic error
-             throw ErrorRegistryError("Requested ErrorCode not found and fallback Registry_UnknownErrorCode is also missing.");
-        }
-        // Ideally, log the original unknown code here as well
-        // For now, just return the generic unknown code error info
+    auto it = registry_map_.find(code); // Use find() to search for the code
+    if (it != registry_map_.end()) {
+        return it->second; // Return the found ErrorInfo
+    } else {
+        // If the code is not found, throw a specific exception
+        // Include the integer value of the unknown code in the message
+        throw ErrorRegistryError("Unknown ErrorCode requested: " + std::to_string(static_cast<int>(code)));
     }
 }
 

--- a/tests/core/error_handling_test.cpp
+++ b/tests/core/error_handling_test.cpp
@@ -1,0 +1,104 @@
+#include "catch2.hpp"
+#include "tooi/core/error_info.h"
+#include "tooi/core/error_registry.h"
+
+#include <string>
+#include <stdexcept> // For std::runtime_error
+
+using tooi::core::ErrorCode;
+using tooi::core::ErrorInfo;
+using tooi::core::ErrorRegistry;
+using tooi::core::ErrorRegistryError;
+using tooi::core::ErrorSeverity;
+
+TEST_CASE("ErrorRegistry Singleton", "[error][registry]") {
+    SECTION("Instance is obtainable and consistent") {
+        ErrorRegistry& instance1 = ErrorRegistry::instance();
+        ErrorRegistry& instance2 = ErrorRegistry::instance();
+        REQUIRE(&instance1 == &instance2); // Check if both references point to the same object
+    }
+}
+
+TEST_CASE("ErrorRegistry get_info", "[error][registry]") {
+    ErrorRegistry& registry = ErrorRegistry::instance();
+
+    SECTION("Retrieve info for known scanner error codes") {
+        // Test a few known scanner error codes
+        ErrorCode code1 = ErrorCode::Scanner_InvalidCharacter;
+        const ErrorInfo* info1 = nullptr;
+        INFO("Checking ErrorCode: Scanner_InvalidCharacter (" << static_cast<int>(code1) << ")");
+        REQUIRE_NOTHROW(info1 = &registry.get_info(code1));
+        REQUIRE(info1 != nullptr);
+        REQUIRE(info1->id == code1);
+        REQUIRE_FALSE(info1->code_str.empty());
+        REQUIRE_FALSE(info1->message_fmt.empty());
+
+        ErrorCode code2 = ErrorCode::Scanner_UnterminatedString;
+        const ErrorInfo* info2 = nullptr;
+        INFO("Checking ErrorCode: Scanner_UnterminatedString (" << static_cast<int>(code2) << ")");
+        REQUIRE_NOTHROW(info2 = &registry.get_info(code2));
+        REQUIRE(info2 != nullptr);
+        REQUIRE(info2->id == code2);
+        REQUIRE_FALSE(info2->code_str.empty());
+        REQUIRE_FALSE(info2->message_fmt.empty());
+
+        ErrorCode code3 = ErrorCode::Scanner_MalformedNumber_MultipleDecimals;
+        const ErrorInfo* info3 = nullptr;
+        INFO("Checking ErrorCode: Scanner_MalformedNumber_MultipleDecimals (" << static_cast<int>(code3) << ")");
+        REQUIRE_NOTHROW(info3 = &registry.get_info(code3));
+        REQUIRE(info3 != nullptr);
+        REQUIRE(info3->id == code3);
+        REQUIRE_FALSE(info3->code_str.empty());
+        REQUIRE_FALSE(info3->message_fmt.empty());
+    }
+    
+    SECTION("Retrieve info for a known general error code") {
+         ErrorCode code = ErrorCode::Registry_UnknownErrorCode;
+         const ErrorInfo* info = nullptr;
+         INFO("Checking ErrorCode: Registry_UnknownErrorCode (" << static_cast<int>(code) << ")");
+         REQUIRE_NOTHROW(info = &registry.get_info(code));
+         REQUIRE(info != nullptr);
+         REQUIRE(info->id == code);
+         REQUIRE_FALSE(info->code_str.empty());
+         REQUIRE_FALSE(info->message_fmt.empty());
+    }
+
+    SECTION("Throws exception for an unknown/invalid error code") {
+        ErrorCode unknown_code = static_cast<ErrorCode>(-999);
+        INFO("Checking throw for unknown ErrorCode: " << static_cast<int>(unknown_code));
+        
+        REQUIRE_THROWS_AS(registry.get_info(unknown_code), ErrorRegistryError);
+        
+        try {
+            registry.get_info(unknown_code);
+        } catch (const ErrorRegistryError& e) {
+            std::string actual_message = e.what();
+            std::string expected_msg_part = "Unknown ErrorCode requested: -999";
+            CAPTURE(unknown_code, expected_msg_part, actual_message); // Capture variables
+            REQUIRE(actual_message.find(expected_msg_part) != std::string::npos);
+        } catch (...) {
+            FAIL("Threw unexpected exception type.");
+        }
+    }
+}
+
+TEST_CASE("ErrorInfo Structure", "[error][info]") {
+    // Basic check for ErrorInfo construction and members
+    // This is less critical as it's mostly a data holder, but good for completeness
+    ErrorInfo info = {
+        ErrorCode::Scanner_InvalidCharacter,
+        ErrorSeverity::Error,
+        "E_SCANNER_INVALID_CHAR",
+        "Invalid character '{0}' found.",
+        "The scanner encountered a character it does not recognize."
+    };
+
+    REQUIRE(info.id == ErrorCode::Scanner_InvalidCharacter);
+    REQUIRE(info.severity == ErrorSeverity::Error);
+    REQUIRE(info.code_str == "E_SCANNER_INVALID_CHAR");
+    REQUIRE(info.message_fmt == "Invalid character '{0}' found.");
+    REQUIRE(info.description == "The scanner encountered a character it does not recognize.");
+}
+
+// We might add tests for ErrorReporter later, potentially mocking dependencies.
+// For now, focus is on the registry and info structures. 

--- a/tests/core/scanner_test.cpp
+++ b/tests/core/scanner_test.cpp
@@ -46,6 +46,7 @@ TEST_CASE("Scanner Basic Initialization", "[scanner]") {
     std::string empty_source = "";
     tooi::core::Scanner scanner(empty_source, error_reporter);
     
+    INFO("Checking empty source: No errors, 1 token (EOF), empty lexeme.");
     std::vector<tooi::core::Token> tokens = scanner.scan_tokens();
     
     REQUIRE_FALSE(error_reporter.had_error());
@@ -93,94 +94,112 @@ TEST_CASE("Scanner Comprehensive Token Coverage", "[scanner]") {
         token_counts[token.type]++;
     }
     
-    // Verify all token types are present (except ERROR which is only generated in error cases)
-    REQUIRE(token_counts[tooi::core::TokenType::LEFT_PAREN] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::RIGHT_PAREN] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::LEFT_BRACE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::RIGHT_BRACE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::LEFT_BRACKET] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::RIGHT_BRACKET] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::COMMA] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::DOT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::MINUS] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PLUS] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::SEMICOLON] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::SLASH] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::ASTERISK] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::AT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::HASHTAG] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::DOLLAR] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::QUESTION] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::COLON] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::CARET] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PERCENT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::AMPERSAND] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PIPE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::TILDE] > 0);
+    // Verify all token types are present using SECTIONs for better reporting
+    SECTION("Single-character tokens are present") {
+        INFO("Checking single-char tokens: ( ) { } [ ] , . - + ; / * @ # $ ? : ^ % & | ~");
+        REQUIRE(token_counts[tooi::core::TokenType::LEFT_PAREN] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::RIGHT_PAREN] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::LEFT_BRACE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::RIGHT_BRACE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::LEFT_BRACKET] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::RIGHT_BRACKET] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::COMMA] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::DOT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::MINUS] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PLUS] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::SEMICOLON] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::SLASH] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::ASTERISK] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::AT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::HASHTAG] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::DOLLAR] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::QUESTION] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::COLON] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::CARET] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PERCENT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::AMPERSAND] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PIPE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::TILDE] > 0);
+    }
     
-    REQUIRE(token_counts[tooi::core::TokenType::BANG] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::BANG_EQUAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::EQUAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::EQUAL_EQUAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::GREATER] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::GREATER_EQUAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::LESS] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::LESS_EQUAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::COLON_COLON] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::MINUS_GREATER] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::EQUAL_GREATER] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::GREATER_GREATER] > 0);
+    SECTION("One or two character tokens are present") {
+        INFO("Checking one/two-char tokens: ! != = == > >= < <= :: -> => >>");
+        REQUIRE(token_counts[tooi::core::TokenType::BANG] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::BANG_EQUAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::EQUAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::EQUAL_EQUAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::GREATER] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::GREATER_EQUAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::LESS] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::LESS_EQUAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::COLON_COLON] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::MINUS_GREATER] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::EQUAL_GREATER] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::GREATER_GREATER] > 0);
+    }
     
-    REQUIRE(token_counts[tooi::core::TokenType::IDENTIFIER_LITERAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::STRING_LITERAL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::NUMBER_LITERAL] > 0);
+    SECTION("Literals are present") {
+        INFO("Checking literals: IDENTIFIER_LITERAL, STRING_LITERAL, NUMBER_LITERAL");
+        REQUIRE(token_counts[tooi::core::TokenType::IDENTIFIER_LITERAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::STRING_LITERAL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::NUMBER_LITERAL] > 0);
+    }
     
-    REQUIRE(token_counts[tooi::core::TokenType::IF] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::ELSE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::FOR] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::WHILE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::DONE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::SKIP] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::TRUE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::FALSE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::NIL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::AND] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::OR] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::NOT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::ADD] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::EXPORT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::WITH] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::SELF] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::AS] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::CALL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::LET] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::SET] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::NEW] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::DO] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::BE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::OF] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::IN] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PUBLIC] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PRIVATE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::RUNNABLE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PURE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PARAM] > 0);
+    SECTION("General keywords are present") {
+        INFO("Checking general keywords: IF, ELSE, FOR, WHILE, DONE, SKIP, TRUE, FALSE, NIL, AND, OR, NOT, ADD, EXPORT, WITH, SELF, AS, CALL, LET, SET, NEW, DO, BE, OF, IN, PUBLIC, PRIVATE, RUNNABLE, PURE, PARAM");
+        REQUIRE(token_counts[tooi::core::TokenType::IF] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::ELSE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::FOR] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::WHILE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::DONE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::SKIP] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::TRUE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::FALSE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::NIL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::AND] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::OR] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::NOT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::ADD] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::EXPORT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::WITH] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::SELF] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::AS] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::CALL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::LET] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::SET] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::NEW] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::DO] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::BE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::OF] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::IN] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PUBLIC] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PRIVATE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::RUNNABLE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PURE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PARAM] > 0);
+    }
     
-    REQUIRE(token_counts[tooi::core::TokenType::INT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::FLOAT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::BYTE] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::STRING] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::BOOL] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::UINT] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::PROTO] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::INT32] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::INT64] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::UINT32] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::UINT64] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::FLOAT32] > 0);
-    REQUIRE(token_counts[tooi::core::TokenType::FLOAT64] > 0);
+    SECTION("Type keywords are present") {
+        INFO("Checking type keywords: INT, FLOAT, BYTE, STRING, BOOL, UINT, PROTO, INT32, INT64, UINT32, UINT64, FLOAT32, FLOAT64");
+        REQUIRE(token_counts[tooi::core::TokenType::INT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::FLOAT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::BYTE] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::STRING] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::BOOL] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::UINT] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::PROTO] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::INT32] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::INT64] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::UINT32] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::UINT64] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::FLOAT32] > 0);
+        REQUIRE(token_counts[tooi::core::TokenType::FLOAT64] > 0);
+    }
     
-    REQUIRE(token_counts[tooi::core::TokenType::END_OF_FILE] > 0);
+    SECTION("END_OF_FILE token is present") {
+        INFO("Checking token: END_OF_FILE");
+        REQUIRE(token_counts[tooi::core::TokenType::END_OF_FILE] > 0);
+    }
 }
 
 // Test case 3: Whitespace and comment skipping
@@ -190,6 +209,7 @@ TEST_CASE("Scanner Skips Whitespace and Comments", "[scanner]") {
     std::string source = "( // this is a line comment\n ) \t { /* another comment */\n }"; 
     tooi::core::Scanner scanner(source, error_reporter);
 
+    INFO("Checking whitespace/comment skipping: Source='( //... ) \t { /*...*/ }', Expected tokens: (, ), {, }, EOF");
     std::vector<tooi::core::Token> tokens = scanner.scan_tokens();
 
     REQUIRE_FALSE(error_reporter.had_error());
@@ -202,11 +222,11 @@ TEST_CASE("Scanner Skips Whitespace and Comments", "[scanner]") {
         tooi::core::TokenType::END_OF_FILE
     };
 
-    // Check token count first for easier debugging
+    CAPTURE(tokens.size(), expected_types.size());
     REQUIRE(tokens.size() == expected_types.size());
 
     for (size_t i = 0; i < expected_types.size(); ++i) {
-        INFO("Checking token at index " << i << ", expected type " << static_cast<int>(expected_types[i]));
+        CAPTURE(i, tokens[i].type, expected_types[i], tokens[i].lexeme);
         REQUIRE(tokens[i].type == expected_types[i]);
     }
 } 


### PR DESCRIPTION
- Updated `ErrorRegistry::get_info` to use `find()` for better error handling, throwing a specific exception for unknown error codes.
- Added a new test file `error_handling_test.cpp` to validate `ErrorRegistry` functionality, including singleton behavior and error code retrieval.
- Enhanced existing tests in `scanner_test.cpp` for better reporting and coverage of token types.
- Added a comment in `token.h` to indicate that the quote token type is reserved and not currently supported.